### PR TITLE
slack通知の文法を正しく修正する

### DIFF
--- a/src/voiceStateUpdateHandler.ts
+++ b/src/voiceStateUpdateHandler.ts
@@ -25,7 +25,7 @@ const sendStartingSessionMessage = (
           },
           {
             type: 'mrkdwn',
-            text: `＜ :slack_call: :watashi: :discord: :in: <https://discord.com/channels/${guild.id}|#${channel.name}> :now:`,
+            text: `＜ :slack_call: :watashi: :in: <https://discord.com/channels/${guild.id}|#${channel.name}> :in: :discord: :now:`,
           },
         ],
       },


### PR DESCRIPTION
close: #41 

動作確認(上がbeforeで下がafterです)
<img width="707" alt="image" src="https://user-images.githubusercontent.com/26830741/173408211-ed12b17d-257a-4ee2-a637-543efa023a94.png">
